### PR TITLE
Fix link cards in burd docs section

### DIFF
--- a/docs/lasr/tutorials/burd.mdx
+++ b/docs/lasr/tutorials/burd.mdx
@@ -28,17 +28,17 @@ BURD serves as an example project to demonstrate LASR's capabilities. It offers 
 <LinkCards numColumns={3} data={[
   { 
     title: '1. Deploy',
-    linkTo: '/tutorials/burd/deploy',
+    linkTo: '/lasr/tutorials/burd/deploy',
     description: 'Follow this guide to deploy your BURD version and start exploring its features.'
   },
   { 
     title: '2. Explore the Code',
-    linkTo: '/tutorials/burd/explore_the_code',
+    linkTo: '/lasr/tutorials/burd/explore_the_code',
     description: 'Check the code used to create the BURD application.'
   },
   { 
     title: '3. Using BURD',
-    linkTo: '/tutorials/burd/using_burd',
+    linkTo: '/lasr/tutorials/burd/using_burd',
     description: 'Learn how to access and explore the BURD interface.'
   },
 ]}/>

--- a/docs/lasr/tutorials/burd/deploy.mdx
+++ b/docs/lasr/tutorials/burd/deploy.mdx
@@ -85,10 +85,10 @@ With a successfully deployed BURD program, you now can learn more about how the 
 <LinkCards numColumns={2} data={[
   { 
     title: 'Explore the Code',
-    linkTo: '/tutorials/burd/explore_the_code',
+    linkTo: '/lasr/tutorials/burd/explore_the_code',
   },
   { 
     title: 'Using BURD',
-    linkTo: '/tutorials/burd/using_burd',
+    linkTo: '/lasr/tutorials/burd/using_burd',
   },
 ]}/>


### PR DESCRIPTION
Fixes #8 

**What does this PR do?**
This PR fixes the links in the link cards within the 'burd docs' section to ensure that all links correctly redirect to their respective pages.

**Why is this needed?**
Some of the link cards in the 'burd docs' section were broken or pointing to outdated URLs, causing navigation issues for users.

https://github.com/user-attachments/assets/93259cea-9226-4980-9f1c-0265b3d25327




